### PR TITLE
SubCoreスケッチをビルドしようとしたときにビルドエラーが発生する事象の解決

### DIFF
--- a/src/ScoreParser.cpp
+++ b/src/ScoreParser.cpp
@@ -4,6 +4,8 @@
  * Copyright 2022 Sony Semiconductor Solutions Corporation
  */
 
+#if defined(ARDUINO_ARCH_SPRESENSE) && !defined(SUBCORE)
+
 #include "ScoreParser.h"
 
 // #define DEBUG (1)
@@ -52,3 +54,5 @@ bool ScoreParser::setPlayTrack(uint32_t mask) {
 uint32_t ScoreParser::getPlayTrack() {
     return play_track_flags_;
 }
+
+#endif  // ARDUINO_ARCH_SPRESENSE


### PR DESCRIPTION
v1.0.0での対応に不具合が混入していることが発覚しました。
SubCore用のスケッチをビルドしたとき、SubCoreでは使用できないライブラリを参照してしまい、ビルドエラーが発生するようになっていました。
本来はこれを解決するためにビルドガードを設けているのですが、今回追加したコードに漏れがあったため、改めて追加します。

エラー発生時のログ(抜粋):
```ビルドログ抜粋.log
In file included from C:\Users\USERNAME\AppData\Local\Arduino15\packages\SPRESENSE\hardware\spresense\2.2.1\libraries\Storage\src/Storage.h:46:0,
                 from C:\Users\USERNAME\AppData\Local\Arduino15\packages\SPRESENSE\hardware\spresense\2.2.1\libraries\SDHCI\src/SDHCI.h:46,
                 from C:\Users\USERNAME\Documents\Arduino\libraries\ssih-music\src\ScoreParser.h:14,
                 from C:\Users\USERNAME\Documents\Arduino\libraries\ssih-music\src\ScoreParser.cpp:7:
C:\Users\USERNAME\AppData\Local\Arduino15\packages\SPRESENSE\hardware\spresense\2.2.1\libraries\File\src/File.h:24:2: error: #error "File library is NOT supported by SubCore."
 #error "File library is NOT supported by SubCore."
  ^
exit status 1
ボードSpresenseに対するコンパイル時にエラーが発生しました。
```
